### PR TITLE
Fix JSON typings.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -249,7 +249,7 @@ declare module 'slate' {
   
     interface TextJSON {
       key?: string;
-      characters: Character[];
+      characters?: Character[];
       leaves: Leaf[];
       object: 'text';
     }

--- a/index.d.ts
+++ b/index.d.ts
@@ -186,7 +186,7 @@ declare module 'slate' {
     interface BlockJSON {
       type: string;
       key?: string;
-      nodes?: Node[];
+      nodes?: NodeJSON[];
       isVoid?: boolean;
       data?: { [key: string]: any };
       object: 'block';
@@ -217,7 +217,7 @@ declare module 'slate' {
     interface InlineJSON {
       type: string;
       key?: string;
-      nodes?: Node[];
+      nodes?: NodeJSON[];
       isVoid?: boolean;
       data?: { [key: string]: any };
       object: 'inline';


### PR DESCRIPTION
This merge request has two commits related to two separate issues I found working through the [Installing Slate Walkthrough](https://docs.slatejs.org/walkthroughs/installing-slate).

## JSON interfaces expect JSON interface children
The current version expects a `Node[]` type (i.e. `Immutable` instance) rather than JSON.

## characters property is optional in TextJSON
The `characters` property has a default and can be omitted. See [this line of code from the slate repository](https://github.com/ianstormtaylor/slate/blob/c1bad2b84c6cf42eaad68b5030ac31e25681bd61/packages/slate/src/models/text.js#L19).