### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Windows-style newlines with a newline ending every file
+[*]
+end_of_line = crlf
+insert_final_newline = true
+
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
With explicit CRLF newlines for easier contribution from Unix-type systems, which does not use CRLF by default.